### PR TITLE
Add Hackbot followup messages 

### DIFF
--- a/app/jobs/leader_check_ins_job.rb
+++ b/app/jobs/leader_check_ins_job.rb
@@ -14,7 +14,7 @@ class LeaderCheckInsJob < ApplicationJob
       im = open_im(user)
       event = construct_fake_event(user, im[:channel][:id])
 
-      convo = Hackbot::Conversations::CheckIn.new(team: slack_team)
+      convo = Hackbot::Conversations::CheckIn.create(team: slack_team)
       convo.handle(event)
       convo.save!
     end
@@ -47,9 +47,12 @@ class LeaderCheckInsJob < ApplicationJob
   end
 
   def active_leader_usernames
+    ['harrison']
+=begin
     active_leaders
       .map(&:slack_username)
       .reject { |u| u.nil? || u.empty? }
+=end
   end
 
   def active_leaders

--- a/app/jobs/slack_prompt_reply_job.rb
+++ b/app/jobs/slack_prompt_reply_job.rb
@@ -1,0 +1,65 @@
+# 1. Checks if a message has been sent since the job was queued
+# 2. If it has, kill the job. If not then continue
+# 3. Send a message prompting a response from the userc:w
+# 4. Queue the job again (Back to step 1.)
+
+class SlackPromptReplyJob < ApplicationJob
+  queue_as :default
+
+  HACK_CLUB_TEAM_ID = 'T0266FRGM'.freeze
+
+  MESSAGE_PROMPT_TEXT = "LISTEN HERE LADDY/LADDESS. YOU SIR/MA'AM ARE G'NNA RESPOND TO THIS HERE SL'CK MESSAGE."
+
+  def perform(username, conversation_id, job_queued_time)
+    convo = Hackbot::Conversations::CheckIn.find(conversation_id)
+
+    if convo.data['last_message_ts'] > job_queued_time 
+      puts 'Message has been replied to in an adequate amount of time'
+      return
+    end
+
+    byebug
+
+    user = user_from_username(username)
+
+    SlackClient.rpc('chat.postMessage', access_token, {
+      channel: user[:id],
+      text: MESSAGE_PROMPT_TEXT,
+      as_user: true
+    })
+  end
+
+  private
+
+  # This constructs a fake Slack event to start the conversation with. It'll be
+  # sent to the conversation's start method.
+  #
+  # This is clearly a hack and our conversation class should be refactored to
+  # account for this use case.
+  def construct_fake_event(user, channel_id)
+    {
+      team_id: slack_team.team_id,
+      user: user[:id],
+      type: 'message',
+      channel: channel_id
+    }
+  end
+
+  def open_im(user)
+    SlackClient::Chat.open_im(user[:id], access_token)
+  end
+
+  def user_from_username(username)
+    @all_users ||= SlackClient::Users.list(access_token)[:members]
+
+    @all_users.find { |u| u[:name] == username }
+  end
+
+   def access_token
+    slack_team.bot_access_token
+   end
+
+  def slack_team
+    Hackbot::Team.find_by(team_id: HACK_CLUB_TEAM_ID)
+  end
+end

--- a/app/jobs/slack_prompt_reply_job.rb
+++ b/app/jobs/slack_prompt_reply_job.rb
@@ -11,7 +11,7 @@ class SlackPromptReplyJob < ApplicationJob
   MESSAGE_PROMPT_TEXT = 'Ping! Would you mind responding to my previous'\
     'message?'.freeze
 
-  def perform(slack_id, conversation_id, job_queued_time)
+  def perform(message, slack_id, conversation_id, job_queued_time)
     convo = Hackbot::Conversations::CheckIn.find(conversation_id)
 
     if convo.data['last_message_ts'].nil?

--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -41,7 +41,6 @@ module Hackbot
           prompt_reply
           :wait_for_meeting_confirmation
         end
-
       end
       # rubocop:enable Metrics/MethodLength
 
@@ -79,7 +78,6 @@ module Hackbot
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       def wait_for_attendance(event)
-
         unless integer?(event[:text])
           msg_channel "I didn't quite understand that. Can you try giving me "\
                       'a single number?'
@@ -125,7 +123,6 @@ module Hackbot
 
       def wait_for_notes(event)
         data['notes'] = event[:text] unless event[:text] =~ /^(no|nope|nah)$/i
-
         ::CheckIn.create!(
           club: club(event),
           leader: leader(event),

--- a/app/models/hackbot/conversations/followupable.rb
+++ b/app/models/hackbot/conversations/followupable.rb
@@ -1,0 +1,32 @@
+module Hackbot
+  module Conversations
+    class Followupable < Hackbot::Conversations::Channel
+      def handle(event)
+        if data['slack_id'].nil?
+          data['slack_id'] = event[:user]
+        else
+          data['last_message_ts'] = timestamp
+          data['last_message'] = event[:text]
+        end
+
+        super(event)
+      end
+
+      DEFAULT_PROMPT_WAIT_TIME = 10.seconds
+
+      def prompt_reply
+        prompt_reply_in DEFAULT_PROMPT_WAIT_TIME
+      end
+
+      def prompt_reply_in(amount)
+        SlackPromptReplyJob.set(wait: amount).perform_later(data['slack_id'], id, timestamp)
+      end
+
+      private
+
+      def timestamp
+        Time.now.iso8601(10)
+      end
+    end
+  end
+end

--- a/app/models/hackbot/conversations/followupable.rb
+++ b/app/models/hackbot/conversations/followupable.rb
@@ -19,7 +19,12 @@ module Hackbot
       end
 
       def prompt_reply_in(amount)
-        SlackPromptReplyJob.set(wait: amount).perform_later(data['slack_id'], id, timestamp)
+        SlackPromptReplyJob.set(
+          wait: amount
+        ).perform_later(
+          data['slack_id'],
+          id, timestamp
+        )
       end
 
       private

--- a/app/models/hackbot/conversations/followupable.rb
+++ b/app/models/hackbot/conversations/followupable.rb
@@ -1,6 +1,10 @@
 module Hackbot
   module Conversations
     class Followupable < Hackbot::Conversations::Channel
+      DEFAULT_PROMPT_DELAY = 10.seconds
+      DEFAULT_PROMPT_TEXT = 'Ping! Would you mind responding to my previous'\
+        'message?'.freeze
+
       def handle(event)
         if data['slack_id'].nil?
           data['slack_id'] = event[:user]
@@ -12,19 +16,19 @@ module Hackbot
         super(event)
       end
 
-      DEFAULT_PROMPT_WAIT_TIME = 10.seconds
 
-      def prompt_reply
-        prompt_reply_in DEFAULT_PROMPT_WAIT_TIME
-      end
-
-      def prompt_reply_in(amount)
+      def prompt_reply(message=DEFAULT_PROMPT_TEXT, amount=DEFAULT_PROMPT_DELAY)
         SlackPromptReplyJob.set(
           wait: amount
         ).perform_later(
+          message,
           data['slack_id'],
-          id, timestamp
-        )
+          id,
+          timestamp)
+      end
+
+      def prompt_reply_in(amount)
+        prompt_reply(DEFAULT_PROMPT_TEXT, DEFAULT_PROMPT_DELAY)
       end
 
       private


### PR DESCRIPTION
This PR gives Hackbot the ability to send messages which prompt replies from leaders who have been pinged during check ins. They currently have 10 seconds to reply by default before Hackbot gets mad, and we're probably going to want to change that.

Follow up behaviour can be added to other `Hackbot::Conversation`s if they subclass `Followupable` and use the available `prompt_reply_in` and `prompt_reply` functions.

**Actionables**:

- [ ] I'd like some feedback on the best way to implement a few things:
  1. [ ] Having prompts which continue to fire until the user replies. Current behaviour is that a user can only be pinged once.
  2. [ ] An API for specifying the message to ping a user with. I really like the `prompt_reply_in 10.seconds` syntax. But it's a bit intimidating to have Hackbot come off as an angry Scotsman. It seems pretty obvious we need a method for specifying the exact message which gets sent to leaders upon being prompted.
- **Before this PR is merged my changes to the `LeaderCheckInsJob` involving `active_leader_usernames` should be reverted.**
- [ ] A general review of this PR.

Close #45.

*These changes are going towards my weekly sprint goal of improving the Hackbot check in experience.*