### PR TITLE
Fix Streak syncing errors

### DIFF
--- a/app/jobs/update_from_streak_job.rb
+++ b/app/jobs/update_from_streak_job.rb
@@ -85,7 +85,10 @@ class UpdateFromStreakJob < ApplicationJob
             # This won't happen because Streakable checks to see if the instance
             # has been .changed? before triggering the API request to Streak.
             # Rails doesn't mark it as changed.
-            instance.send(association.plural_name) << instance_to_associate
+            unless instance.send(association.plural_name)
+                           .include? instance_to_associate
+              instance.send(association.plural_name) << instance_to_associate
+            end
           end
         end
       end

--- a/app/jobs/update_from_streak_job.rb
+++ b/app/jobs/update_from_streak_job.rb
@@ -33,7 +33,7 @@ class UpdateFromStreakJob < ApplicationJob
           attrs_to_update[attribute] = box[:fields][key.to_sym]
         end
 
-        instance.update_attributes_without_streak(attrs_to_update)
+        instance.update_attributes!(attrs_to_update)
 
         # Delete relationships that aren't present on Streak
         old_linked_box_keys = instance.linked_streak_box_keys

--- a/app/models/concerns/streakable.rb
+++ b/app/models/concerns/streakable.rb
@@ -84,14 +84,14 @@ module Streakable
   end
 
   def create_box
-    return if streak_key_val
+    unless streak_key_val
+      resp = StreakClient::Box.create_in_pipeline(self.class.pipeline_key, name)
 
-    resp = StreakClient::Box.create_in_pipeline(self.class.pipeline_key, name)
-
-    # Need to use self here because it'll try to create a variable by default
-    # (try removing 'self.' from the beginning and running tests to see for
-    # yourself)
-    self.streak_key_val = resp[:key]
+      # Need to use self here because it'll try to create a variable by default
+      # (try removing 'self.' from the beginning and running tests to see for
+      # yourself)
+      self.streak_key_val = resp[:key]
+    end
 
     update_streak_box
   end

--- a/app/models/concerns/streakable.rb
+++ b/app/models/concerns/streakable.rb
@@ -40,12 +40,6 @@ module Streakable
     before_destroy :destroy_box
   end
 
-  def update_attributes_without_streak(attrs)
-    self.class.skip_callback(:update, :before, :update_box_if_changed)
-    update_attributes(attrs)
-    self.class.set_callback(:update, :before, :update_box_if_changed)
-  end
-
   def destroy_without_streak!
     self.class.skip_callback(:destroy, :before, :destroy_box)
     destroy!

--- a/db/migrate/20170222152231_prevent_duplicate_club_leader_relationships.rb
+++ b/db/migrate/20170222152231_prevent_duplicate_club_leader_relationships.rb
@@ -1,0 +1,27 @@
+class PreventDuplicateClubLeaderRelationships < ActiveRecord::Migration[5.0]
+  def up
+    # Add an id column so we have a unique way to refer to each record
+    execute 'ALTER TABLE clubs_leaders ADD COLUMN id bigserial PRIMARY KEY'
+
+    # Remove duplicate entries (see
+    # https://wiki.postgresql.org/wiki/Deleting_duplicates for source)
+    execute <<-SQL
+DELETE FROM clubs_leaders
+WHERE id IN (SELECT id
+              FROM (SELECT id,
+                      ROW_NUMBER() OVER (PARTITION BY club_id, leader_id ORDER BY id) AS rnum
+                    FROM clubs_leaders) t
+              WHERE t.rnum > 1);
+SQL
+
+    # Remove the id column because it's no longer needed
+    execute 'ALTER TABLE clubs_leaders DROP COLUMN id'
+
+    add_index :clubs_leaders, [:club_id, :leader_id],
+              unique: true, name: 'index_clubs_leaders_uniqueness'
+  end
+
+  def down
+    remove_index :clubs_leaders, name: 'index_clubs_leaders_uniqueness'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119233357) do
+ActiveRecord::Schema.define(version: 20170222152231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20170119233357) do
   create_table "clubs_leaders", id: false, force: :cascade do |t|
     t.integer "club_id"
     t.integer "leader_id"
+    t.index ["club_id", "leader_id"], name: "index_clubs_leaders_uniqueness", unique: true, using: :btree
     t.index ["club_id"], name: "index_clubs_leaders_on_club_id", using: :btree
     t.index ["leader_id"], name: "index_clubs_leaders_on_leader_id", using: :btree
   end

--- a/spec/support/shared_examples/streakable.rb
+++ b/spec/support/shared_examples/streakable.rb
@@ -48,6 +48,34 @@ RSpec.shared_examples 'Streakable' do
         instance.send(model.key_attribute)
       }.from(nil).to(streak_key)
     end
+
+    # In the case that you want to create a new record for a Streak box that
+    # already exists
+    context 'when streak_key is set' do
+      let(:attrs) { attributes_from_created_instance(model) }
+      let(:instance) { model.new(attrs) }
+      let(:box_client) { class_double(StreakClient::Box).as_stubbed_const }
+
+      it "doesn't create another box, but does send updates" do
+        expect(box_client).to_not receive(:create_in_pipeline)
+
+        expect_update_box(
+          streak_client_double: box_client,
+          streak_key: attrs[model.key_attribute],
+          notes: attrs[model.notes_attribute],
+          linked_box_keys: [] # TODO: Don't do this
+        )
+
+        expect_update_box_fields(
+          streak_client_double: box_client,
+          model: model,
+          streak_key: attrs[model.key_attribute],
+          attrs: attrs
+        )
+
+        instance.save
+      end
+    end
   end
 
   context 'updating' do


### PR DESCRIPTION
This pull request makes a few changes to how Streak syncing is handled to fix a few edge cases.

- If the creation of a new record in the DB fails during syncing, an exception is now thrown (previously, it was ignored)
  - This closes #27 
- Remove duplicate club <-> leader relationships and prevent future ones from being created (previously, a club could have an associate with the same leader twice – or vice versa)
- If a Streakable model is created with a `streak_key`, don't skip sending updates back to Streak when saving
  - This handles the case where a Club is created with `streak_key`, `name`, and `address` set, but missing `latitude` and `longitude`. Previously the `address` would be geocoded and `latitude` and `longitude` would be set, but the new `latitude` and `longitude` wouldn't be sent to Streak (as long as the model was just being created, it'd send updates if the address later changes in an existing record)