### PR TITLE
Implement Streak task API endpoints

### DIFF
--- a/lib/streak_client.rb
+++ b/lib/streak_client.rb
@@ -1,6 +1,7 @@
 # Resources
-require 'streak_client/pipeline'
 require 'streak_client/box'
+require 'streak_client/pipeline'
+require 'streak_client/task'
 
 # Errors
 require 'common_client/errors/api_error'
@@ -18,7 +19,7 @@ module StreakClient
     end
 
     # rubocop:disable Metrics/MethodLength
-    def request(method, path, params = {}, headers = {})
+    def request(method, path, params = {}, headers = {}, json = true)
       payload = nil
 
       raise AuthenticationError, 'No API key provided' unless @api_key
@@ -29,8 +30,12 @@ module StreakClient
 
       case method
       when :post
-        headers['Content-Type'] = 'application/json'
-        payload = params.to_json
+        if json
+          headers['Content-Type'] = 'application/json'
+          payload = params.to_json
+        else
+          payload = params
+        end
       when :put
         headers[:params] = params
       when :get

--- a/lib/streak_client/task.rb
+++ b/lib/streak_client/task.rb
@@ -1,0 +1,75 @@
+module StreakClient
+  module Task
+    class << self
+      def all_in_box(box_key)
+        StreakClient.request(:get, "/v2/boxes/#{box_key}/tasks")[:results]
+      end
+
+      def find(task_key)
+        StreakClient.request(:get, "/v2/tasks/#{task_key}")
+      end
+
+      def create(box_key, text, due_date: nil, assignees: [])
+        StreakClient.request(
+          :post, "/v2/boxes/#{box_key}/tasks", {
+            text: text,
+            due_date: time_to_ms_since_epoch(due_date),
+            assigned_to_sharing_entries:
+              construct_sharing_entries(assignees).to_json
+          },
+          {},
+          false
+        )
+      end
+
+      def update(task_key, params)
+        # If the user passes assignees to update, transform the given array of
+        # emails into proper sharing entries.
+        if params.key? :assignees
+          assignees = params[:assignees] || []
+
+          params[:assigned_to_sharing_entries] =
+            construct_sharing_entries(assignees)
+
+          params.delete(:assignees)
+        end
+
+        # If the user passes a due date to update, similarly transform it to
+        # milliseconds since epoch
+        if params.key? :due_date
+          params[:due_date] = time_to_ms_since_epoch(params[:due_date])
+        end
+
+        StreakClient.request(:post, "/v2/tasks/#{task_key}", params)
+      end
+
+      def delete(task_key)
+        StreakClient.request(:delete, "/v2/tasks/#{task_key}")
+      end
+
+      private
+
+      # Converts an array of emails to a formatted Streak sharing entry, ready
+      # to be passed to Streak's API.
+      #
+      # Example:
+      #
+      #   [ "foo@example.com", "sally@foobar.com" ]
+      #
+      #   turns into
+      #
+      #   [ { email: "foo@example.com" }, { email: "sally@foobar.com" } ]
+      #
+      #   which you can then pass to any Streak endpoint that requests a
+      #   "sharing entry" -- you may have to serialize this to a JSON string for
+      #   certain endpoints (I'm looking at you POST /v2/:box_key/tasks)
+      def construct_sharing_entries(emails)
+        emails.map { |e| { email: e } }
+      end
+
+      def time_to_ms_since_epoch(time)
+        (time.to_f * 1000).to_i
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the API endpoints for Streak tasks. I've successfully been able to go through the following flow with these changes:

1. List all Streak tasks in a box

    ```ruby
    tasks = StreakClient::Task.all_in_box("BOX_KEY")
    ```

2. Fetch a specific Streak task given its key

    ```ruby
    StreakClient::Task.find(tasks.first[:key])
    ```

3. Create a Streak task

    ```ruby
   new_task = StreakClient::Task.create(
      "BOX_KEY",
      "testing lifecycle of tasks",
      due_date: 3.days.from_now,
      assignees: ["harrison@hackclub.com", "max@hackclub.com"]
    )
    ```

4. Update a Streak task

    ```ruby
    StreakClient::Task.update(
      new_task[:key],
      text: "actually, do this instead",
      due_date: 1.week.from_now,
      assignees: ["zach@zachlatta.com","max@hackclub.com"]
    )
    ```

5. Delete a Streak task

    ```ruby
    StreakClient::Task.delete(new_task[:key])
    ```