### PR TITLE
Properly resolve leaders by Slack ID during check-ins

### DIFF
--- a/app/models/hackbot/conversations/check_in.rb
+++ b/app/models/hackbot/conversations/check_in.rb
@@ -226,9 +226,14 @@ module Hackbot
       end
 
       def leader(event)
-        @leader ||= Leader.find_by(slack_id: event[:user])
+        pipeline_key = Rails.application.secrets.streak_leader_pipeline_key
+        slack_id_field = :'1020'
 
-        @leader
+        @leader_box ||= StreakClient::Box
+                        .all_in_pipeline(pipeline_key)
+                        .find { |b| b[:fields][slack_id_field] == event[:user] }
+
+        @leader ||= Leader.find_by(streak_key: @leader_box[:key])
       end
     end
     # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
This PR changes how we resolve messages to leaders during the check-in process to properly query Streak first so we don't end up with a local record with a box that was deleted on Streak.

Flow this fixes:

1. Leader is onboarded and creates four boxes for themselves
2. Kyle removes the first three boxes
3. We look up the leader by their Slack ID during check-ins and resolve the first box that was deleted on Streak
4. We try to create a task with that box, but get a 404 error from Streak

Now we first do the lookup on Streak and then resolve it to a local record in our DB.