### PR TITLE
Properly resolve leaders from Slack ID during stats command

### DIFF
--- a/app/models/hackbot/conversations/stats.rb
+++ b/app/models/hackbot/conversations/stats.rb
@@ -33,9 +33,14 @@ module Hackbot
       end
 
       def leader(event)
-        slack_user = SlackClient::Users.info(event[:user], access_token)[:user]
+        pipeline_key = Rails.application.secrets.streak_leader_pipeline_key
+        slack_id_field = :'1020'
 
-        Leader.find_by(slack_username: slack_user[:name])
+        @leader_box ||= StreakClient::Box
+                        .all_in_pipeline(pipeline_key)
+                        .find { |b| b[:fields][slack_id_field] == event[:user] }
+
+        @leader ||= Leader.find_by(streak_key: @leader_box[:key])
       end
 
       def open_im(slack_id)


### PR DESCRIPTION
Same code as #137, but in the `hackbot stats` command. I'd like to introduce a `current_leader` method in the base conversation class, but I think it's worth holding off on that until #136 is merged because it's such an easy refactor.