### PR TITLE
Remove invalid case in check-ins

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -52,11 +52,6 @@ module Hackbot
 
           default_follow_up 'wait_for_no_meeting_reason'
           :wait_for_no_meeting_reason
-        else
-          msg_channel copy('meeting_confirmation.invalid')
-
-          default_follow_up 'wait_for_meeting_confirmation'
-          :wait_for_meeting_confirmation
         end
       end
       # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
The 'else' case can never trigger because the method will restart itself if
it gets something other than a 'yes' or 'no' action.