### PR TITLE
Add `hackbot sql` command and introduce admin users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'geocoder', '~> 1.4'
 gem 'rack-cors', require: 'rack/cors'
 gem 'rest-client', '~> 2.0'
 gem 'sentry-raven', '~> 2.4'
+gem 'terminal-table', '~> 1.7'
 gem 'timezone', '~>1.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
     thor (0.19.1)
     thread_safe (0.3.6)
     timezone (1.2.6)
@@ -302,6 +304,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec (~> 1.0)
   spring-watcher-listen (~> 2.0.0)
+  terminal-table (~> 1.7)
   timezone (~> 1.0)
   tzinfo-data
   vcr (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ DEFAULT_STREAK_TASK_ASSIGNEE
 # Slack channel to mirror Hackbot interactions to
 HACKBOT_MIRROR_CHANNEL_ID
 
+# Comma separated list of Slack user IDs that Hackbot should recognize as
+# admins. User IDs can be from multiple Slack teams.
+HACKBOT_ADMINS
+
 # Streak box to use for demo check-ins
 STREAK_DEMO_USER_BOX_KEY
 

--- a/app/models/hackbot/dispatcher.rb
+++ b/app/models/hackbot/dispatcher.rb
@@ -7,6 +7,7 @@ module Hackbot
       Hackbot::Interactions::Gifs,
       Hackbot::Interactions::Help,
       Hackbot::Interactions::SetPoc,
+      Hackbot::Interactions::Sql,
       Hackbot::Interactions::Stats
     ].freeze
 

--- a/app/models/hackbot/helpers.rb
+++ b/app/models/hackbot/helpers.rb
@@ -26,5 +26,13 @@ module Hackbot
         access_token
       )[:user]
     end
+
+    ADMIN_UIDS = Rails.application.secrets.hackbot_admins
+
+    def current_admin?
+      return true if ADMIN_UIDS.include? event[:user]
+
+      false
+    end
   end
 end

--- a/app/models/hackbot/interactions/set_poc.rb
+++ b/app/models/hackbot/interactions/set_poc.rb
@@ -7,6 +7,8 @@ module Hackbot
       DESCRIPTION = 'set the given leader as the point of contact for their '\
                     'club (staff only)'.freeze
 
+      before_handle :ensure_admin
+
       def start
         streak_key = captured[:streak_key]
 
@@ -127,6 +129,14 @@ module Hackbot
 
       def get_last_arg(text)
         text.split(' ').last
+      end
+
+      def ensure_admin
+        return if current_admin?
+
+        msg_channel(copy('not_admin'))
+
+        throw :abort
       end
     end
   end

--- a/app/models/hackbot/interactions/sql.rb
+++ b/app/models/hackbot/interactions/sql.rb
@@ -1,0 +1,133 @@
+class Executer
+  def execute(query)
+    # Slack recommends limiting messages sent to channels to 4000 characters in
+    # https://api.slack.com/rtm#limits.
+    #
+    # This can't be a constant because this file is reloaded whenever
+    # Hackbot::Interactions::Sql and causes problems when constants are defined
+    # inside of Executer.
+    char_limit = 4000
+
+    res = fmted_result_from_query(query)
+
+    truncate(res, char_limit)
+  end
+
+  private
+
+  def truncate(str, char_limit)
+    truncated = str.first(char_limit)
+
+    if truncated != str
+      split = truncated.split("\n")
+
+      all_but_last_line = split[0...-1]
+      all_but_last_line << '...truncated...'
+
+      all_but_last_line.join("\n")
+    else
+      str
+    end
+  end
+
+  def fmted_result_from_query(query)
+    final_res = nil
+
+    # We need to execute the given query in a separate thread because if it
+    # fails, we don't want the SQL transaction that the current interaction is
+    # in to be aborted.
+    #
+    # Rails transactions are done by threads, so by putting this in a separate
+    # thread, any queries will be executed outside of the current transaction.
+    in_new_thread_with_conn do |conn|
+      begin
+        res = conn.execute(query)
+        final_res = format_result(query, res)
+      rescue ActiveRecord::StatementInvalid => e
+        # Return the thrown exception converted to a string with the query
+        # added, so we can display it to the user.
+        #
+        # We call .strip to remove the trailing newlines that PG errors
+        # have.
+        final_res = "> #{query}\n\n" + e.original_exception.to_s.strip
+      end
+    end
+
+    final_res
+  end
+
+  def in_new_thread_with_conn(&block)
+    Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection(&block)
+    end.join
+  end
+
+  def format_result(query, pg_result)
+    Terminal::Table.new(
+      title: query,
+      headings: pg_result.fields,
+      rows: pg_result.values
+    ).to_s
+  end
+end
+
+module Hackbot
+  module Interactions
+    class Sql < Command
+      TRIGGER = /sql (?<query>.*)/
+
+      USAGE = 'sql <query>'.freeze
+      DESCRIPTION = 'execute the given SQL query and return the results '\
+                    '(staff only)'.freeze
+
+      before_handle :ensure_admin
+
+      def start
+        data['query'] = captured[:query]
+
+        msg_channel(text: copy('confirm.text', query: data['query']),
+                    attachments: [actions: [{ text: 'Yes' }, { text: 'No' }]])
+
+        :confirm
+      end
+
+      def confirm
+        return unless action
+
+        case action[:value]
+        when Hackbot::Utterances.yes then execute
+        when Hackbot::Utterances.no then cancel
+        end
+      end
+
+      private
+
+      def execute
+        send_action_result(copy('confirm.proceed'))
+        res = Executer.new.execute(data['query'])
+        msg_channel to_code(res)
+      end
+
+      def cancel
+        send_action_result(copy('confirm.cancel'))
+      end
+
+      # Convert the given string to a formatted Slack code block.
+      def to_code(str)
+        "```\n" + str + "\n```"
+      end
+
+      def ensure_admin
+        return if current_admin?
+
+        if state == 'start'
+          msg_channel copy('not_admin_start')
+        else
+          send_msg(event[:user], copy('not_admin_in_progress'))
+        end
+
+        throw :abort
+      end
+    end
+  end
+end

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ machine:
     GIPHY_API_KEY: fake_giphy_api_key
     DEFAULT_STREAK_TASK_ASSIGNEE: email@email.email
     HACKBOT_MIRROR_CHANNEL_ID: fake_channel_id
+    HACKBOT_ADMINS: fake,admin,list
     STREAK_DEMO_USER_BOX_KEY: fake_streak_key
 
 test:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -35,6 +35,7 @@ common: &common
   default_streak_task_assignee: <%= ENV.fetch("DEFAULT_STREAK_TASK_ASSIGNEE") %>
 
   hackbot_mirror_channel_id: <%= ENV.fetch("HACKBOT_MIRROR_CHANNEL_ID") %>
+  hackbot_admins: <%= ENV.fetch("HACKBOT_ADMINS").split(",") %>
 
   # This is for the DemoCheckIn interaction
   streak_demo_user_box_key: <%= ENV.fetch("STREAK_DEMO_USER_BOX_KEY") %>

--- a/lib/data/copy/set_poc.yml
+++ b/lib/data/copy/set_poc.yml
@@ -1,3 +1,4 @@
+not_admin: You must be an administrator to use this command.
 start:
     invalid: I can't find that leader :-?
     no_clubs: <%= leader_name %> is not associated with any clubs.

--- a/lib/data/copy/sql.yml
+++ b/lib/data/copy/sql.yml
@@ -1,0 +1,9 @@
+not_admin_start: You must be an administrator to use this command.
+not_admin_in_progress: You must be an administrator to interact with this command.
+confirm:
+  text: |
+    Are you sure? This will execute `<%= query %>` and return the results publicly to this channel.
+
+    *This can be destructive. Be careful.*
+  proceed: ':white_check_mark: *Execute the query*'
+  cancel: ':no_entry: *Do not execute*'


### PR DESCRIPTION
This PR introduces a new command, `hackbot sql <query>`, and implements basic functionality for having "admin users". It also changes `set-poc` to verify that the user is an admin.

`hackbot sql` usage: `hackbot sql SELECT id, created_at FROM clubs` (must be an admin to use this command)

For now, admin users are defined through the `HACKBOT_ADMINS` environment variable as a comma-separated list of Slack user IDs. This'll have to be set to something before merging.