### PR TITLE
Implement Streak deletion syncing

### DIFF
--- a/app/jobs/update_from_streak_job.rb
+++ b/app/jobs/update_from_streak_job.rb
@@ -1,14 +1,18 @@
 class UpdateFromStreakJob < ApplicationJob
   queue_as :default
 
-  # Just a quick note, we're going to temporarily disable basic complexity
-  # checks from Rubocop for now because this method is going to need a real
-  # refactor at some point to implement Streak's V2 API.
-  def perform(*) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def perform(*)
     # Since we're going to be doing a ton of reflection, we need to make sure
     # that the entire application is loaded into memory.
     Rails.application.eager_load!
 
+    ActiveRecord::Base.transaction { sync }
+  end
+
+  # Just a quick note, we're going to temporarily disable basic complexity
+  # checks from Rubocop for now because this method is going to need a real
+  # refactor at some point to implement Streak's V2 API.
+  def sync # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     streakable_models = ActiveRecord::Base.descendants.select do |model|
       model.included_modules.include? Streakable
     end


### PR DESCRIPTION
Closes #39.

From @paked on these changes:

> This April, Hack Club brings… STREAK DELETIONS! The critically acclaimed feature which has been in the works for the past 6 months. Starring Zach, as ‘The Creator’, Harrison and Max as ‘The Pushers’ and, finally, reclaiming his award winning role: Hackbot, as ‘That Bot.’
> 
> Here’s what critics are saying! ‘Eh, needs work.’ 4/5, ‘A tremendous feat in the world of software engineering’ 5/5, ‘A massive step forward in the equality of Streak and non-Streak data’ 5/5

This PR makes three changes:

- Only sync associations that are Enumerable (i.e. don't try to sync linked boxes to `point_of_contact`)
- Run syncs inside of a DB transaction
- Implement Streak deletion syncing

Assigned both @MaxWofford and @paked. Either of you are welcome to review / merge, not sure who's interested in taking point.