### PR TITLE
Remove extra message in check_ins

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -82,11 +82,6 @@ module Hackbot
 
           default_follow_up 'wait_for_no_meeting_reason'
           :wait_for_no_meeting_reason
-        else
-          msg_channel copy('meeting_confirmation.invalid')
-
-          default_follow_up 'wait_for_meeting_confirmation'
-          :wait_for_meeting_confirmation
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -82,6 +82,9 @@ module Hackbot
 
           default_follow_up 'wait_for_no_meeting_reason'
           :wait_for_no_meeting_reason
+        else
+          default_follow_up 'wait_for_meeting_confirmation'
+          :wait_for_meeting_confirmation
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/data/copy/check_in.yml
+++ b/lib/data/copy/check_in.yml
@@ -16,7 +16,6 @@ meeting_confirmation:
         action_result: ":no_entry: You did not have a meeting"
         ask_why: That's a shame! Why didn't you meet?
     previous_meeting_day: ":white_check_mark: You had a meeting on <%= day %>"
-    invalid: I'm not very smart yet and had trouble understanding you :-/. Try saying something like 'yes' or 'no'.
 
 no_meeting_reason: Gotcha. Are you planning on having a club meeting in the future?
 


### PR DESCRIPTION
Currently this message is only triggered if there is a delay between Hackbot and
Slack, which leads to some confusing messages from Hackbot