### PR TITLE
Fix bug where confirmation stage wouldn't update

### DIFF
--- a/app/models/hackbot/interactions/check_in.rb
+++ b/app/models/hackbot/interactions/check_in.rb
@@ -266,6 +266,7 @@ module Hackbot
         :wait_for_submit_confirmation
       end
 
+      # rubocop:disable Metrics/MethodLength
       def wait_for_submit_confirmation
         return :wait_for_submit_confirmation unless action
 
@@ -279,8 +280,14 @@ module Hackbot
           send_action_result copy('submit_confirmation.restart.action_result')
 
           restart_check_in
+        else
+
+          default_follow_up 'wait_for_submit_confirmation'
+
+          :wait_for_submit_confirmation
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       # rubocop:disable Metrics/MethodLength
       def prompt_for_submit


### PR DESCRIPTION
This was caused because a delay would cause clients to submit old action values
that would pass through the case statement without triggering any action and
setting their conversations to 'finish' -- which is our default when a
conversation method doesn't return anything.